### PR TITLE
fix(pages): scss selector

### DIFF
--- a/src/pages/page1/page1.scss
+++ b/src/pages/page1/page1.scss
@@ -1,3 +1,3 @@
-.page1-page {
+page1-page {
 
 }

--- a/src/pages/page1/page1.ts
+++ b/src/pages/page1/page1.ts
@@ -3,7 +3,8 @@ import { Component } from '@angular/core';
 import { NavController } from 'ionic-angular';
 
 @Component({
-  templateUrl: 'page1.html'
+  templateUrl: 'page1.html',
+  selector: 'page1-page'
 })
 export class Page1 {
   constructor(public navCtrl: NavController) {

--- a/src/pages/page2/page2.scss
+++ b/src/pages/page2/page2.scss
@@ -1,3 +1,3 @@
-.page2-page {
+page2-page {
 
 }

--- a/src/pages/page2/page2.ts
+++ b/src/pages/page2/page2.ts
@@ -3,7 +3,8 @@ import { Component } from '@angular/core';
 import { NavController, NavParams } from 'ionic-angular';
 
 @Component({
-  templateUrl: 'page2.html'
+  templateUrl: 'page2.html',
+  selector: 'page2-page'
 })
 export class Page2 {
   selectedItem: any;


### PR DESCRIPTION
if the `selector` parameter is not set the pages `@Component` there is no default class that gets applied to the `ng-component` element
